### PR TITLE
Bump log4j-core from 2.2 to 2.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,7 +202,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.2</version>
+      <version>2.13.2</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.mybatis/mybatis -->


### PR DESCRIPTION
Bumps log4j-core from 2.2 to 2.13.2.

Signed-off-by: dependabot[bot] <support@github.com>